### PR TITLE
Write import statement only once and fix if we have multiple functions

### DIFF
--- a/src/sushipy/index.py
+++ b/src/sushipy/index.py
@@ -47,7 +47,6 @@ def _open_find(
                 data = {"type": extract[0], "name": name, "all": extract, "file": file}
 
                 # get arguments from functions and save it
-
                 # pylint: disable=unsupported-binary-operation
                 arg_data = get_arg(name, data)
                 DATA.append(data | {"arg": arg_data})
@@ -95,18 +94,18 @@ def save():
         mkdir("out")
 
     # create new file
-    for x in DATA:
-        rich_print(
-            f"[bold yellow]sushi[/bold yellow]   saving indexed functions ({x.get('file')})"
-        )
+    file_data_old = DATA[0]['file'].split("/")[-1]
+    file_data = file_data_old.replace("." + config["main"]["lang"], "")
 
-        file_data_old = x.get("file").split("/")[-1]
-        file_data = file_data_old.replace("." + config["main"]["lang"], "")
+    with open(file=f"out/{file_data}.py", mode="w", encoding="UTF-8") as f:
+        f.write("from sushipy.execute import Execute\n")
 
-        with open(file=f"out/{file_data}.py", mode="w", encoding="UTF-8") as f:
-            f.write("from sushipy.execute import Execute\n")
+        # Write each function to our created file
+        for x in DATA:
+            rich_print(
+                f"[bold yellow]sushi[/bold yellow]   saving indexed functions ({x.get('file')})"
+            )
 
-            # print(x)
             fname = x["name"]
 
             args = ""


### PR DESCRIPTION
This fixes an issue where if the our source file contained multiple functions, only the first function would get generated.

With the for() function the file would get overwritten instead of looped over for each function name.

Using `DATA[0]` we assume there is at least one element, this approach can be improved.